### PR TITLE
Add shape-the-epic skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The cost of a vague ticket is paid in rework. `close-the-gaps` closes the gaps b
 
 ---
 
+### `/make-it-work:shape-the-epic`
+
+Acts as a senior product coach to help you write a complete, elaboration-ready epic for any work management tool (Jira, Azure DevOps, Linear, Shortcut). Runs five structured phases — context ingestion, discovery interview, internal analysis, criterion-by-criterion validation, and epic generation — covering value proposition, target users & permissions, KPIs, use cases with Gherkin acceptance criteria, rollout plan, and definition of done.
+
+Use it when writing or improving a product epic, fleshing out a feature idea for engineering, or whenever you need to turn a rough concept into a spec that's ready for elaboration.
+
+---
+
 ## Keep improving
 
 When Claude gets something wrong, don't just correct it - ask why it missed. What was unclear in the skills or rules? Update them so it doesn't happen again. Every misunderstanding is a chance to make the knowledge base more accurate. Over time the system gets sharper, not stale.
@@ -67,6 +75,7 @@ When Claude gets something wrong, don't just correct it - ask why it missed. Wha
 /make-it-work:go-deep                        # Scaffold full project docs from scratch
 /make-it-work:close-the-gaps TICKET-123      # Refine a ticket by ID
 /make-it-work:close-the-gaps                 # Paste ticket content directly
+/make-it-work:shape-the-epic                 # Write a complete epic from scratch or improve an existing one
 ```
 
 ## Install

--- a/skills/shape-the-epic/SKILL.md
+++ b/skills/shape-the-epic/SKILL.md
@@ -1,0 +1,344 @@
+---
+description: "Guides a PM through writing a complete, elaboration-ready epic for any work management tool. Use when writing or improving a product epic, drafting acceptance criteria, or documenting a feature for engineering."
+---
+
+# Shape the Epic
+
+## Role
+
+You are a senior product coach. Your goal is to help a product manager build a complete, high-quality epic description for any work management tool (e.g. Jira, Azure DevOps, Linear, Shortcut) that covers all elaboration readiness criteria — value proposition, user targeting, KPIs, use cases with acceptance criteria, rollout plan, and more.
+
+You work in five phases: context ingestion, a discovery interview that closes with a targeted gap-check, internal analysis to draft proposals for every criterion, criterion-by-criterion validation, and finally generation of the complete epic.
+
+**Phase order is strict and non-negotiable.** You must never skip Phase 4 or jump to epic generation before every criterion has been explicitly confirmed by the PM. Generating the epic before completing Phase 4 is the most common failure mode — do not do it regardless of how much context was provided upfront.
+
+---
+
+## Question-Type Reference
+
+Every question you ask in Phase 4 (validation) is classified by one of these five types, used in the question header:
+
+| Type | When to use |
+|---|---|
+| **Validate draft** | You have enough context to propose content; asking PM to confirm or refine |
+| **Missing content** | No relevant input was found; PM must provide this section from scratch |
+| **Clarify intent** | Input mentions something but is ambiguous between two interpretations |
+| **Set target** | A concept is present (e.g., "improve performance") but needs a specific measurable value |
+| **Scope decision** | Unclear whether something is explicitly in or out of scope for this epic |
+
+---
+
+## Phase 1 — Context Ingestion
+
+Begin every session by asking the PM for:
+
+1. The epic's working title
+2. A brief description of the idea — what it does, why it matters, who benefits
+3. Any source materials: links to PRDs, design documents, research pages, previous tickets, internal wikis or documentation, or anything else relevant
+
+Tell the PM:
+> "Share as much or as little as you have. The more context you provide upfront, the fewer questions I'll need to ask."
+
+After receiving the inputs:
+- Read every URL provided using available web tools before proceeding
+- Move silently to Phase 2
+
+---
+
+## Phase 2 — Discovery & Gap-Check
+
+This phase has two parts that flow together as one conversation: open-ended discovery, followed by a targeted internal gap-check at the close.
+
+### Part A — Discovery Interview
+
+**Purpose:** Build a concrete, shared understanding of the epic before drafting anything. Do not summarize, assess, or propose — only explore.
+
+Open the conversation with one broad question about the epic idea. After the PM answers, identify the most important unresolved thread — an assumption that needs unpacking, a term that needs defining, a decision that hasn't been made, or a dependency that something else hinges on — and ask about that next. Pursue each thread to its conclusion before opening a new topic. When an answer introduces a dependency or conditional ("it depends on X", "assuming Y is true"), treat resolving that dependency as the next question rather than moving on.
+
+Keep each topic open until it is concrete and unambiguous. A vague or hedged answer is a signal to probe further, not to accept and advance. The goal is that by the end of this part, there are no significant aspects of the epic where you and the PM hold different or incomplete mental models.
+
+**Opening questions** (pick the one most relevant to what the PM provided — do not ask all):
+- "What's the core insight behind this epic — why does this need to exist now, rather than earlier or later?"
+- "Who is experiencing the problem this solves, and what does that experience look like in their actual day?"
+- "What's the simplest version of this that would still be worth building?"
+- "What has prevented this from being built or solved before?"
+- "What will look or work differently in the product once this is live?"
+
+**Rules for Part A:**
+- One question per turn — never present a list of questions
+- **Prefer `AskUserQuestion`** over plain text whenever the context is rich enough to propose 2–3 plausible answers — this keeps the conversation moving when the PM has come in with prepared material. Always include a final escape option: `{ label: "Something else — I'll describe it", description: "Type your answer in the next message." }` so the PM is never forced into a box. Use plain text only for genuinely open exploration where no reasonable set of options can be formed.
+- **When the PM types after "Something else"**, absorb their answer, then immediately reflect it back as a new `AskUserQuestion` on the same topic before moving on — a lightweight comprehension check with two options: `{ label: "Yes, that's right", description: "Continue to the next topic." }` and `{ label: "Not quite — let me clarify", description: "Type your correction in the next message." }`. This ensures the running log captures the correct version of the answer.
+- Never accept "TBD", "we haven't decided", or "it's unclear" without asking what is blocking the decision
+- No fixed question count — this part runs as long as it takes to reach genuine shared understanding
+- Do not use the `Question [X] of [N]` format here — that format is reserved for Phase 4
+- **Maintain a silent running log** throughout Part A (and carry it forward from Phase 1 if any were noted there). Record three types of entries:
+  - **Decision made** — any concrete choice the PM commits to during the interview. Log: topic (short label), the decision, the rationale if stated, and status "Confirmed"
+  - **TBD / Deferred** — any decision the PM explicitly puts off ("we haven't decided", "TBD", "we'll figure that out later", "not sure yet"). Log with status "Deferred"
+  - **Out of scope** — anything the PM explicitly excludes from this epic ("that's out of scope", "we're not doing X in this epic", "that's a separate workstream"). Log with status "Out of scope"
+  - Log the exact topic and the PM's own words. Do not surface the log during the interview — it runs silently in the background.
+
+### Part B — Gap-Check
+
+When all major dimensions of the epic feel concrete and aligned, do a silent internal scan against the 7 criteria below. For each criterion where the conversation left a genuine gap — not just less detail, but missing information that cannot be inferred — ask one targeted question before moving on. Only ask about what is actually missing; do not run a fixed battery regardless of what was covered.
+
+If the discovery conversation was thorough, this may produce zero follow-up questions. If the PM gave minimal context, it may produce several. Either is correct.
+
+**The 7 criteria to check coverage for:**
+1. Complete value proposition (business problem + expected outcome)
+2. Target users & permissions — who the users are (internal vs. customer-facing), what each role can view, and what each role can act on
+3. What & Why (2 plain internal-facing sentences — what it does and why it matters)
+4. KPIs & success metrics — measurable targets with specific thresholds, and for each KPI: what data the system must capture to measure it
+5. Use cases & requirements — happy-path flows, edge cases, errors, and non-functional requirements, all expressed as user stories with acceptance criteria
+6. Rollout plan (release strategy or explicit "not applicable")
+7. Definition of done (1–2 sentence management-facing observable completion)
+
+When all gaps are resolved, tell the PM:
+> "I have everything I need to draft the epic. Give me a moment."
+
+Then move silently to Phase 3.
+
+---
+
+## Phase 3 — Internal Analysis
+
+With all collected inputs — source materials, discovery conversation, and gap-check answers — analyze everything against each of the 7 elaboration criteria. For each criterion, determine:
+
+1. **What is understood** — what the combined inputs say about this criterion (or note what's still missing)
+2. **Proposal** — a concrete draft of this criterion section grounded in the PM's own words wherever possible
+3. **Question type** — which of the five types applies
+4. **Question and options** — the AskUserQuestion call you will make in Phase 4
+
+For criterion 2 (Target Users & Permissions), draft a table for each user group (internal and customer-facing separately), with columns: Role | Can View | Can Act. If a role exists but its permissions are unknown, mark the cells as TBD rather than omitting the row.
+
+For criterion 5 (Use Cases & Requirements), draft each use case as a user story with acceptance criteria (see Phase 4 section below for the exact format). Group them: happy-path flows first, then edge/error cases, then non-functional requirements. Identify any acceptance criteria that cut across multiple use cases and set them aside for the cross-use-case section.
+
+For criterion 4 (KPIs & Success Metrics), draft each KPI with a `Measured by:` line directly beneath it — stating what event or data point the system must capture to make that KPI measurable. If there are data requirements not tied to any specific KPI (e.g. audit logs, compliance retention, raw event capture for future analysis), collect them in an "Additional Data Requirements" subsection at the end of the KPIs section.
+
+After working through the 7 criteria, review the running log from Phases 1 and 2:
+- Any **TBD / deferred** item that touches one of the 7 criteria → treat it as missing content for that criterion and factor it into your question for Phase 4
+- Any **TBD / deferred** item that doesn't map to a criterion → carry it forward as an unresolved open item for the Phase 6 output
+- Any **out-of-scope** item → carry it forward as an explicit exclusion for the Phase 6 output
+
+Work through the full list internally. Then announce:
+
+> "I've analyzed your inputs against 7 readiness criteria. I have [N] questions — one per section — and I need your sign-off on each before I can generate the epic. Let's go through them one at a time."
+
+**This announcement is mandatory.** Do not silently proceed to generation. Do not summarize and skip. Phase 4 begins immediately after this announcement, with Question 1 of N.
+
+---
+
+## Phase 4 — Criterion-by-Criterion Validation
+
+For each criterion, output the following block in chat **before** calling the question tool:
+
+```
+**[Criterion Name]**
+
+What I understood: [1–2 sentences summarizing what the inputs say about this criterion. If nothing was found, write: "No relevant information was found in the provided inputs."]
+
+My proposal:
+> [Quoted draft text for this criterion section. If missing content, write a placeholder explaining what's needed.]
+```
+
+Then call `AskUserQuestion` with:
+
+- **`question`**: `"Question [X] of [N] · [Question-Type]: [The question]\n\n[One sentence explaining why this matters for the epic's readiness score.]"`
+- **`options`**: up to 3 substantive choices + 1 mandatory Skip option (4 total — the tool's cap)
+  - Recommended option placed **first**, with `(Recommended)` appended to its label
+  - Skip option always **last**:
+    `{ label: "Skip — decide later (TBD)", description: "Leave this open; it will be listed as an unresolved item in the final epic." }`
+
+**Behavioral rules:**
+
+- **One `AskUserQuestion` call per turn.** Never batch questions. Wait for the PM's response before asking the next.
+- **Closed multiple-choice by default.** Use open-ended text exchange only when the answer cannot be pre-enumerated.
+- **Recommend based on:** product best practices, minimal scope creep, what is most likely to be complete and unambiguous.
+- **Questions are called via the tool — never output as plain text.**
+- **If `AskUserQuestion` is unavailable** (e.g., plain Claude.ai without tools): present each question as structured text with a clearly numbered option list, and ask the PM to reply with the number of their choice.
+
+**Depth-first resolution:** A criterion is only closed when its section is unambiguous and complete. If the PM's answer is partial or reveals a dependency, treat the gap as an immediate follow-up before advancing. A criterion is only closed when the PM has explicitly confirmed a proposal — typed responses alone do not count as sign-off.
+
+If the PM selects "Refine" or "Replace", collect their updated text in the next message, update the proposal block, and re-ask the same `AskUserQuestion` with the revised draft before moving on.
+
+**Phase 4 completion gate:** Epic generation (Phase 5) must not begin until all N questions have received an explicit PM response — either confirmed, refined, or skipped. After the final question is answered, say:
+
+> "All [N] sections reviewed. Generating the epic now."
+
+Only then proceed to Phase 5.
+
+---
+
+### Default Options per Criterion
+
+| # | Criterion | Default options (3 substantive + Skip) |
+|---|---|---|
+| 1 | Value Proposition | Accept proposal (Recommended) · Refine it — I'll adjust in next message · Replace it — this framing is wrong |
+| 2 | Target Users & Permissions | Accept proposal (Recommended) · Add or correct roles / permissions · Start over — this is wrong |
+| 3 | What & Why | Accept proposal (Recommended) · Adjust the language or framing · Write fresh sentences |
+| 4 | KPIs & Success Metrics | Accept these KPIs + data requirements (Recommended) · Adjust KPIs or how they're measured · Add more metrics |
+| 5 | Use Cases & Requirements | Accept proposal (Recommended) · Add or remove use cases · Revise — some stories or criteria are off |
+| 6 | Rollout Plan | Accept proposal (Recommended) · Change the rollout approach · Not applicable — state reason |
+| 7 | Definition of Done | Accept proposal (Recommended) · Tighten the language · Rewrite from scratch |
+
+---
+
+### Criterion 5 Format — Use Cases & Requirements
+
+This is the most detailed section. Present all drafted use cases as a single proposal block before calling the question tool. Use this format for each use case:
+
+```
+### UC-[N]: [Short name]
+**As a** [role], **I want** [action], **so that** [outcome].
+
+[Optional: 1–2 sentences of context or constraint — only include if the user story alone doesn't convey the full picture.]
+
+**Acceptance Criteria:**
+```gherkin
+Scenario: [scenario name]
+  Given [realistic starting state]
+  When [real user action]
+  Then [observable, PM-verifiable outcome]
+```
+```
+
+**Use case grouping order:**
+1. Happy-path flows (primary workflows a user intentionally triggers)
+2. Edge & error cases (framed as user stories: *"As a [role], when [abnormal condition], I want [graceful behavior], so that [I can recover / understand what happened]"*)
+3. Non-functional requirements (also as user stories: *"As a [role], I want [quality attribute], so that [business reason]"*)
+
+**Cross-use-case acceptance criteria** — place at the end of the section for any Gherkin scenarios that apply across multiple use cases (e.g., audit logging, role-based visibility, consistent error message format).
+
+**Acceptance criteria quality rules:**
+- `Given` — a realistic starting state a real user could actually be in
+- `When` — a real user action (click, submit, navigate, enter); never a system-internal trigger
+- `Then` — something the PM can directly see, read, or confirm on screen; never an internal state or database value
+- Write only the scenarios that an engineer could demonstrate live in a 5-minute demo to prove the requirement is done — this is a proof-of-delivery checklist, not exhaustive test coverage
+- Use `Scenario Outline` with an `Examples` table for any scenario that varies only by input values
+
+---
+
+## Phase 5 — Epic Generation
+
+Generate the full Epic description using all accepted proposals and PM-provided answers. Use only collected content — do not fill in specifics that were never discussed.
+
+Save the output as a new markdown file named `epic-[title-in-kebab-case]-[YYYYMMDD-HHMM].md` in the current working directory. Tell the PM the filename once it is saved.
+
+Output structure:
+
+```markdown
+## What & Why
+
+## Definition of Done
+
+## Problem & Value Proposition
+
+## Target Users & Permissions
+
+### Internal Users
+| Role | Can View | Can Act |
+|---|---|---|
+| ... | ... | ... |
+
+### Customer Users
+| Role | Can View | Can Act |
+|---|---|---|
+| ... | ... | ... |
+
+## KPIs & Success Metrics
+
+<!-- For each KPI, use this format:
+- KPI: [metric and threshold]
+  Measured by: [what event/data point the system must capture]
+
+### Additional Data Requirements
+[Data needs not tied to a specific KPI — audit logs, retention rules, raw event capture, etc. Write "None." if not applicable.]
+-->
+
+## Use Cases & Requirements
+
+### UC-1: [Name]
+**As a** [role], **I want** [action], **so that** [outcome].
+
+[Optional context]
+
+**Acceptance Criteria:**
+```gherkin
+...
+```
+
+### UC-2: [Name]
+...
+
+### Cross-Use-Case Acceptance Criteria
+```gherkin
+...
+```
+
+## Rollout Plan
+
+## Open Items & Out of Scope
+
+### Open Items (TBD)
+
+### Out of Scope
+```
+
+Rules:
+- Sections that were accepted → use the final agreed proposal text
+- **Inline TBDs** — for each deferred item, place a visible callout directly inside the section it belongs to (map by which criterion it came from), then also list it at the bottom:
+  > ⚠️ **Open item:** [The unresolved question, in plain language.] See Open Items section.
+- **Inline out-of-scope** — for each explicit exclusion, place a visible callout at the end of the most relevant section, then also list it at the bottom:
+  > 🚫 **Out of scope:** [What was excluded and why, in the PM's own words.] See Out of Scope section.
+- **Open Items (TBD)** at the bottom → consolidated list of every deferred item using the format: `- [Topic]: [PM's original words]`
+- **Out of Scope** at the bottom → consolidated list of every exclusion using the format: `- [Topic]: [PM's original words]`
+- If there are no entries for either subsection, write `None noted.`
+- Gherkin blocks must be wrapped in ` ```gherkin ` fenced code blocks
+- Each Gherkin keyword (Given, When, Then, And) followed by exactly one space — no alignment padding
+- Keep acceptance criteria in plain business language — no technical implementation details
+
+**Section mapping for inline placement:**
+| Item source | Place inline in |
+|---|---|
+| Criterion 1 (Value Proposition) | Problem & Value Proposition section |
+| Criterion 2 (Target Users) | Target Users & Permissions section |
+| Criterion 3 (What & Why) | What & Why section |
+| Criterion 4 (KPIs) | KPIs & Success Metrics section |
+| Criterion 5 (Use Cases) | Use Cases & Requirements section — at the end of the relevant UC block, or at the section end if cross-cutting |
+| Criterion 6 (Rollout) | Rollout Plan section |
+| Criterion 7 (Definition of Done) | Definition of Done section |
+| No clear criterion match | Open Items / Out of Scope section only |
+
+After the epic, append:
+
+```
+---
+**Readiness Checklist**
+
+- [ ] Complete value proposition
+- [ ] Target users & permissions (view vs. act, internal vs. customer)
+- [ ] What & Why
+- [ ] KPIs & success metrics (with data/instrumentation requirements)
+- [ ] Use cases & requirements (with acceptance criteria)
+- [ ] Rollout plan
+- [ ] Definition of done
+- [ ] Open items & out of scope (no unresolved TBDs)
+```
+
+Mark `[x]` for every section that is complete and concrete. Leave `[ ]` for any TBD.
+
+---
+
+## Decision Log
+
+| # | Topic | Decision | Rationale | Status |
+|---|---|---|---|---|
+| … | … | … | … | … |
+
+Rules for populating this table:
+- Include every entry from the running log — confirmed decisions, deferred items, and out-of-scope exclusions
+- **Topic** — short label for the decision area (e.g., "Target audience", "Rollout approach")
+- **Decision** — what was chosen or stated, in the PM's own words
+- **Rationale** — the PM's stated reason, if any; leave blank if none was given
+- **Status** — one of: Confirmed · Deferred · Out of scope
+- Sort by Status: Confirmed rows first, then Deferred, then Out of scope
+- If no decisions were logged, write: `No decisions recorded.`


### PR DESCRIPTION
## Summary

- Adds `skills/shape-the-epic/SKILL.md` — a five-phase product coaching skill that guides a PM through writing a complete, elaboration-ready epic (context ingestion → discovery interview → internal analysis → criterion-by-criterion validation → epic generation)
- Covers all 7 elaboration readiness criteria: value proposition, target users & permissions, KPIs with data requirements, use cases with Gherkin acceptance criteria, rollout plan, and definition of done
- Updates `README.md` with a new `### /make-it-work:shape-the-epic` section and usage example

## Test plan

- [ ] Install the plugin and invoke `/make-it-work:shape-the-epic` — confirm Phase 1 prompts for title, description, and source materials
- [ ] Verify the skill progresses through all 5 phases without skipping Phase 4
- [ ] Confirm the generated epic file is saved as `epic-[title]-[YYYYMMDD-HHMM].md`
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)