### PR TITLE
Bump plugin version to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "make-it-work",
   "description": "Know your code. Close your gaps. Ship with confidence.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "insideout-ai"
   },


### PR DESCRIPTION
## Summary
- Bumps `.claude-plugin/plugin.json` version to 1.1.0 to release the shape-the-epic, slice-the-epic, and close-my-loops skills that were already merged into main but never published under a versioned tag.

## Test plan
- [ ] `claude plugin validate .claude-plugin/plugin.json` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)